### PR TITLE
Bugfix: textarea was appended twice

### DIFF
--- a/mailer/models.py
+++ b/mailer/models.py
@@ -142,7 +142,7 @@ class Message(models.Model):
     def get_email_content_for_admin_field(self):
         contents = []
 
-        if self.email.body:
+        if self.email.body and self.email.body.strip():
             contents.append('<textarea cols="150" rows="20">%s</textarea>' % self.email.body)
 
         for alternative in self.email.alternatives:


### PR DESCRIPTION
In case of empty HTML message, the textarea with
the content was appended twice.
