### PR TITLE
Template sender uses template model from settings if available

### DIFF
--- a/mailer/email_templates/__init__.py
+++ b/mailer/email_templates/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.template import Context, Template
+from django.db.models.loading import get_model
 
 from mailer import send_html_mail
 from mailer.email_templates.models import EmailTemplate
@@ -60,7 +61,7 @@ class EmailTemplateSender(object):
 
     @classmethod
     def get_email_template_class(cls):
-        return EmailTemplate
+        return get_model(*config.MAILER_TEMPLATE_MODEL) if config.MAILER_TEMPLATE_MODEL else EmailTemplate
 
     @classmethod
     def get_email_template_object(cls, template_name=None, template_obj=None):

--- a/mailer/email_templates/config.py
+++ b/mailer/email_templates/config.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-
 try:
     EMAIL_DEFAULT_FROM_EMAIL = settings.EMAIL_DEFAULT_FROM_EMAIL
 except:
@@ -13,3 +12,12 @@ try:
     EMAIL_DEFAULT_PRIORITY = settings.EMAIL_DEFAULT_PRIORITY
 except:
     raise ImproperlyConfigured('email_templates needs EMAIL_DEFAULT_PRIORITY set in settings.py')
+
+try:
+    if hasattr(settings, 'MAILER_TEMPLATE_MODEL'):
+        app_name, class_name = settings.MAILER_TEMPLATE_MODEL.split('.')
+        MAILER_TEMPLATE_MODEL = (app_name, class_name)
+    else:
+        MAILER_TEMPLATE_MODEL = None
+except:
+    raise ImproperlyConfigured('MAILER_TEMPLATE_MODEL in settings.py is not valid. Should be "app_name.class_name".')


### PR DESCRIPTION
If the default EmailTemplate model is enough for the project, it works as it did before. If one needs to subclass EmailTemplate, the class can be specified in Django settings and Mailer uses that class instead.
